### PR TITLE
Ability to generate the slug from a method

### DIFF
--- a/lib/behavior/behavior.js
+++ b/lib/behavior/behavior.js
@@ -1,7 +1,8 @@
 Astro.createBehavior({
   name: 'slug',
   options: {
-    fieldName: 'name',
+    fieldName: null,
+    methodName: null,
     slugFieldName: 'slug',
     canUpdate: false,
     unique: true,

--- a/lib/behavior/events.js
+++ b/lib/behavior/events.js
@@ -176,15 +176,21 @@ events.beforeSave = function() {
   var classBehavior = Class.getBehavior('slug');
   var options = classBehavior.options;
 
-  // Check if a field from which we want to create a slug has been
-  // modified.
-  var modified = doc.getModified();
-  if (!_.has(modified, options.fieldName)) {
-    return;
-  }
+  var value;
+  if (options.fieldName) {
+    // Check if a field from which we want to create a slug has been
+    // modified.
+    var modified = doc.getModified();
+    if (!_.has(modified, options.fieldName)) {
+      return;
+    }
 
-  // Get a value of the field to make a slug from.
-  var value = doc.get(options.fieldName);
+    // Get a value of the field to make a slug from.
+    value = doc.get(options.fieldName);
+  } else {
+    // Apply the method to get a value to make a slug from.
+    value = doc[options.methodName]();
+  }
 
   // If a value is null then we can not create a slug.
   if (_.isNull(value)) {


### PR DESCRIPTION
Quick PR enabling slug generation from a method. E.g. with methods like <code>fullTitle()</code> who returns <code>title + " by " + author</code>. Feel free to implement a "real" way of defining a method within the slug definition ;)
