### PR TITLE
executes `generateSlug` method inside the `afterInit` event listener

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 1.2.1 (2015-11-11)
+
+- execute `generateSlug` method inside the `afterInit` event listener for instances created without calling `doc.set`
+
 # 1.2.0 (2015-10-30)
 
 - Introduced behavior methods thanks to which you can run behavior at any moment (`Class.getBehavior('slug').generateSlug(doc)`)

--- a/lib/behavior/behavior.js
+++ b/lib/behavior/behavior.js
@@ -19,7 +19,7 @@ Astro.createBehavior({
           var Class = doc.constructor;
 
           Astro.utils.warn(
-            'This method is depracated. You should use "' + Class.getName() +
+            'This method is deprecated. You should use "' + Class.getName() +
             '.getBehavior("slug").generateSlug(doc);" instead.'
           );
 

--- a/lib/behavior/events.js
+++ b/lib/behavior/events.js
@@ -1,5 +1,29 @@
 events = {};
 
+events.afterInit = function() {
+  var doc = this;
+  var Class = doc.constructor;
+
+  if(!doc._isNew) {
+    return;
+  }
+
+  // Find a class on which the behavior had been set.
+  var classBehavior = Class.getBehavior('slug');
+  var options = classBehavior.options;
+
+  // Find the definition of the field.
+  var field = classBehavior.definition.fields[options.slugFieldName];
+  if(_.has(field, 'default')) {
+    return
+  }
+
+  var value = doc[options.slugFieldName];
+  if(value === null) {
+    Class.getBehavior('slug').generateSlug(doc);
+  }
+};
+
 events.beforeSave = function() {
   var doc = this;
   var Class = doc.constructor;

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
   summary: 'Slug behavior for Meteor Astronomy',
-  version: '1.2.0',
-  name: 'jagi:astronomy-slug-behavior',
-  git: 'https://github.com/jagi/meteor-astronomy-slug-behavior.git'
+  version: '1.2.1',
+  name: 'zvictor:astronomy-slug-behavior',
+  git: 'https://github.com/zvictor/meteor-astronomy-slug-behavior.git'
 });
 
 Package.onUse(function(api) {

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.1.0.2');
 
-  api.use('jagi:astronomy@1.2.0');
+  api.use('zvictor:astronomy@1.2.3');
   api.use('underscore');
 
   // Behavior.


### PR DESCRIPTION
Proposal of workaround for #5.

I tried to define `generateSlug` as default method of the field, but it seems that it is not possible because we have no access to the doc data this early.
